### PR TITLE
fix: require list of `blob/accept` invocation links and `AgentMessage` of proof chain in `SignAddPieces`

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/storacha/go-ucanto/client"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/invocation"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/message"
 	"github.com/storacha/go-ucanto/core/receipt"
 	"github.com/storacha/go-ucanto/core/receipt/fx"
 	"github.com/storacha/go-ucanto/core/receipt/ran"
@@ -111,11 +113,15 @@ func TestClient_SignAddPieces(t *testing.T) {
 		{{Key: "piece1-key", Value: "piece1-value"}},
 		{{Key: "piece2-key", Value: "piece2-value"}},
 	}
+	task := testutil.RandomCID(t)
 	rcpt, err := receipt.Issue(
 		testutil.Alice,
 		result.Ok[ok.Unit, failure.IPLDBuilderFailure](ok.Unit{}),
-		ran.FromLink(testutil.RandomCID(t)),
+		ran.FromLink(task),
 	)
+	require.NoError(t, err)
+
+	msg, err := message.Build(nil, []receipt.AnyReceipt{rcpt})
 	require.NoError(t, err)
 
 	signature, err := client.SignAddPieces(
@@ -125,7 +131,8 @@ func TestClient_SignAddPieces(t *testing.T) {
 		firstAdded,
 		pieceData,
 		metadata,
-		[][]receipt.AnyReceipt{{rcpt}},
+		[][]ipld.Link{{task}},
+		[][]message.AgentMessage{{msg}},
 		delegation.WithProof(delegation.FromDelegation(mkproof(t))),
 	)
 	require.NoError(t, err)

--- a/pkg/inprocess/signer.go
+++ b/pkg/inprocess/signer.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/storacha/filecoin-services/go/eip712"
 	"github.com/storacha/go-ucanto/core/delegation"
-	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/message"
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/storacha/piri-signing-service/pkg/signer"
 	"github.com/storacha/piri-signing-service/pkg/types"
@@ -46,7 +47,8 @@ func (s *Signer) SignAddPieces(ctx context.Context,
 	firstAdded *big.Int,
 	pieceData [][]byte,
 	metadata [][]eip712.MetadataEntry,
-	proofs [][]receipt.AnyReceipt,
+	proofs [][]ipld.Link,
+	proofData [][]message.AgentMessage,
 	options ...delegation.Option) (*eip712.AuthSignature, error) {
 	return s.signer.SignAddPieces(clientDataSetId, firstAdded, pieceData, metadata)
 }

--- a/pkg/inprocess/signer_test.go
+++ b/pkg/inprocess/signer_test.go
@@ -82,7 +82,7 @@ func TestSigner_SignAddPieces(t *testing.T) {
 		{{Key: "piece2-key", Value: "piece2-value"}},
 	}
 
-	signature, err := signer.SignAddPieces(ctx, testutil.Alice, clientDataSetId, firstAdded, pieceData, metadata, nil)
+	signature, err := signer.SignAddPieces(ctx, testutil.Alice, clientDataSetId, firstAdded, pieceData, metadata, nil, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, signature)
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -7,7 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/storacha/filecoin-services/go/eip712"
 	"github.com/storacha/go-ucanto/core/delegation"
-	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/ipld"
+	"github.com/storacha/go-ucanto/core/message"
 	"github.com/storacha/go-ucanto/ucan"
 )
 
@@ -69,7 +70,8 @@ type SigningService interface {
 		firstAdded *big.Int,
 		pieceData [][]byte,
 		metadata [][]eip712.MetadataEntry,
-		proofs [][]receipt.AnyReceipt,
+		proofs [][]ipld.Link, // links to `blob/accept` tasks
+		proofData [][]message.AgentMessage, // invocations and receipts for the proof chain
 		options ...delegation.Option,
 	) (*eip712.AuthSignature, error)
 


### PR DESCRIPTION
This is a fix to the client API to accept a list of proof links as well as a bundle of invocations/receipts in an agent message.

There's no change to the wire protocol, just a change to the arguments that `SignAddPieces` accepts.

The client needs to send the following data (this hasn't changed):

* `blob/accept` invocation (proof of upload request)
* `blob/accept` receipt (attestation of data received and FX link to `pdp/accept` invocation)
* `pdp/accept`invocation (proof that the blob entered the PDP pipeline on the node)
* `pdp/accept` receipt (attestation of blob-> piece mapping and aggregate inclusion proof)

So, while a receipt in itself can contain the blocks for a invocation, it's kinda weird for it to contain the blocks for an fx invocation and its receipt. Hence the switch.

We don't really have anything better than `AgentMessage` right now (this will be a https://github.com/ucan-wg/container in UCAN 1.0) but it is basically what we need because we have a bunch of invocations and receipts we want to send for each piece in an aggregate.