### PR TITLE
fix: signing key is now an externally provisioned secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,6 @@ jobs:
       aws-region: ${{ secrets.WARM_STAGING_AWS_REGION }}
       region: ${{ secrets.WARM_STAGING_AWS_REGION }}
       private-key: ${{ secrets.WARM_STAGING_PRIVATE_KEY }}
-      signing-key: ${{ secrets.WARM_STAGING_SIGNING_KEY }}
       cloudflare-zone-id: ${{ secrets.WARM_STAGING_CLOUDFLARE_ZONE_ID }}
       cloudflare-api-token: ${{ secrets.WARM_STAGING_CLOUDFLARE_API_TOKEN }}
 
@@ -57,6 +56,5 @@ jobs:
       aws-region: ${{ secrets.FORGE_PROD_AWS_REGION }}
       region: ${{ secrets.FORGE_PROD_AWS_REGION }}
       private-key: ${{ secrets.FORGE_PROD_PRIVATE_KEY }}
-      signing-key: ${{ secrets.FORGE_PROD_SIGNING_KEY }}
       cloudflare-zone-id: ${{ secrets.FORGE_PROD_CLOUDFLARE_ZONE_ID }}
       cloudflare-api-token: ${{ secrets.FORGE_PROD_CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -30,8 +30,6 @@ on:
         required: true
       region:
         required: true
-      signing-key:
-        required: true
       cloudflare-zone-id:
         required: true
       cloudflare-api-token:
@@ -53,7 +51,6 @@ env:
   TF_VAR_domain_base:
   TF_VAR_allowed_account_id: ${{ secrets.aws-account-id }}
   TF_VAR_region: ${{ secrets.region }}
-  TF_VAR_signing_key: ${{ secrets.signing-key }}
   TF_VAR_cloudflare_zone_id: ${{ secrets.cloudflare-zone-id }}
   CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare-api-token }}
   DEPLOY_ENV: ci

--- a/.storoku.json
+++ b/.storoku.json
@@ -14,7 +14,8 @@
   "secrets": [
     {
       "name": "SIGNING_SERVICE_SIGNING_KEY",
-      "variable": true
+      "variable": false,
+      "external": true
     }
   ],
   "tables": null,

--- a/deploy/.env.terraform.tpl
+++ b/deploy/.env.terraform.tpl
@@ -3,7 +3,6 @@ TF_WORKSPACE= # your name here
 TF_VAR_app=signer
 TF_VAR_did= # did for your env
 TF_VAR_private_key= # private_key or your env -- do not commit to repo!
-TF_VAR_signing_key= # enter a value for SIGNING_SERVICE_SIGNING_KEY secret
 TF_VAR_allowed_account_id=505595374361
 TF_VAR_region=us-east-2
 TF_VAR_cloudflare_zone_id=37783d6f032b78cd97ce37ab6fd42848

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -40,7 +40,7 @@ provider "aws" {
 
 
 module "app" {
-  source = "github.com/storacha/storoku//app?ref=v0.5.0"
+  source = "github.com/storacha/storoku//app?ref=v0.5.2"
   private_key = var.private_key
   private_key_env_var = "SIGNING_SERVICE_SERVICE_KEY"
   httpport = 7446
@@ -61,8 +61,9 @@ module "app" {
   # enter secret values your app will use here -- these will be available
   # as env vars in the container at runtime
   secrets = { 
-    "SIGNING_SERVICE_SIGNING_KEY" = var.signing_key
   }
+  # enter external secrets (provisioned out-of-band) here
+  external_secrets = ["SIGNING_SERVICE_SIGNING_KEY",]
   # enter any sqs queues you want to create here
   queues = []
   caches = []

--- a/deploy/app/variables.tf
+++ b/deploy/app/variables.tf
@@ -50,8 +50,3 @@ variable "network" {
   type        = string
   default     = "hot"
 }
-
-variable "signing_key" {
-  description = "value for signing_service_signing_key secret"
-  type = string
-}

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -49,7 +49,7 @@ provider "aws" {
 }
 
 module "shared" {
-  source = "github.com/storacha/storoku//shared?ref=v0.5.0"
+  source = "github.com/storacha/storoku//shared?ref=v0.5.2"
   providers = {
     aws = aws
     aws.dev = aws.dev


### PR DESCRIPTION
Needs https://github.com/storacha/storoku/pull/31 to land first.

Use the support for externally provisioned secrets in storoku v0.5.2 to make the SIGNING_KEY secret external. It's value will be removed from the repo and we will be able to manage it directly in AWS Secrets Manager.
